### PR TITLE
Add `query` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ If you are using this plugin in a Typescript project, adding the type definition
 
 <br />
 
+### `query`
+
+If you want to import only some components as React components, and import other ones as standard string resource path, you can use the `query` option:
+
+```js
+export default defineConfig({
+    //...
+    query: 'as-react-component'
+});
+```
+
+In your jsx/tsx file:
+
+```jsx
+import MyReactSvg from './my_svg.svg?as-react-component'
+import MySvg from './my_svg'
+…
+
+<MyReactSvg /> // This one is treated as a react component
+<img src={MySvg} /> // This one is imported as a resource path
+```
+
 ### `keepEmittedAssets`
 
 By default, the plugin will prevent transformed SVG assets to be emitted when building the production bundle (when using Vite 2.5.0 or later). If you want or need to have those files emitted anyway, pass the `{keepEmittedAssets: true}` option:


### PR DESCRIPTION
Hey hey !

Here is a proposal of something we added on our side that might be cool to have directly in the plugin
It's pretty common to identify thanks to a query a specific behavior during the import (see [Query Suffixes](https://vitejs.dev/guide/features.html#import-with-query-suffixes) from Vite documentation):
- It allows you to import some components as components (like `my_svg?component`) and use them like `<MySvg />`, but also have the classic string path behavior and use it like `<img src={MySvg}…`
- It also eases the migration from some webpack plugins

Feel free to give any comments/suggestions 👌 